### PR TITLE
Add subscriber self-service page and operations dashboard

### DIFF
--- a/webadmin/README.md
+++ b/webadmin/README.md
@@ -32,6 +32,8 @@ python manage.py runserver 127.0.0.1:8001
 Usage
 - Open http://127.0.0.1:8001
 - Login with Twitch (Allauth). Allowed logins are promoted to staff automatically.
+- The top page now shows an operations dashboard (EventSub health, reminder counts, etc.).
+- `/status/` exposes a self-service page where logged-in viewers can check their latest link state.
 - Open “ロールDM送信”, select a role, enter message, optionally add a file, and submit.
 
 Notes

--- a/webadmin/panel/static/panel/css/panel.css
+++ b/webadmin/panel/static/panel/css/panel.css
@@ -279,6 +279,315 @@ input[type="submit"]:focus-visible,
   transform: none;
   box-shadow: none;
 }
+
+.stat-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 16px 18px;
+  backdrop-filter: blur(14px);
+  min-height: 110px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.stat-label {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
+}
+
+.stat-value {
+  font-size: 1.9rem;
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+.stat-subtext {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.tier-breakdown {
+  margin-top: 28px;
+}
+
+.tier-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.tier-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tier-label {
+  color: var(--color-text-muted);
+}
+
+.tier-count {
+  font-weight: 600;
+}
+
+.status-grid {
+  display: grid;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+@media (min-width: 960px) {
+  .status-grid {
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  }
+}
+
+.status-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: clamp(20px, 4vw, 32px);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.status-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.status-card-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.status-card-header a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.status-card-header a:hover,
+.status-card-header a:focus-visible {
+  text-decoration: underline;
+}
+
+.status-badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.status-badge.is-success {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #bbf7d0;
+}
+
+.status-badge.is-warning {
+  background: rgba(251, 191, 36, 0.18);
+  border-color: rgba(251, 191, 36, 0.45);
+  color: #fef3c7;
+}
+
+.status-badge.is-danger {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.5);
+  color: #fecaca;
+}
+
+.status-badge.is-muted {
+  background: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.status-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.data-list {
+  margin: 0;
+  display: grid;
+  gap: 14px 18px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.data-list div {
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.data-list dt {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.data-list dd {
+  margin: 4px 0 0;
+  font-weight: 600;
+}
+
+.note-section h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+.note-list {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--color-text);
+  display: grid;
+  gap: 6px;
+}
+
+.guide-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+}
+
+.status-section {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.status-list li {
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.status-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.status-title {
+  font-weight: 600;
+}
+
+.status-meta {
+  color: var(--color-text-muted);
+}
+
+.status-body {
+  margin-top: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: var(--color-text);
+}
+
+.status-note {
+  color: var(--color-text-muted);
+}
+
+.profile-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.profile-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.profile-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.table-wrapper {
+  margin-top: 20px;
+  overflow-x: auto;
+}
+
+.event-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.event-table th,
+.event-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+.event-table th {
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.event-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.section-title {
+  margin: 24px 0 12px;
+  font-size: 1.05rem;
+  color: var(--color-text-muted);
+}
+
 @media (max-width: 640px) {
   .site-header {
     flex-direction: column;

--- a/webadmin/panel/templates/panel/base.html
+++ b/webadmin/panel/templates/panel/base.html
@@ -15,8 +15,11 @@
         <div class="brand">NeiBot 管理パネル</div>
         <nav class="site-nav" aria-label="メインメニュー">
           <a href="{% url 'index' %}">ダッシュボード</a>
-          <a href="{% url 'broadcast' %}">ロールDM送信</a>
           {% if user.is_authenticated %}
+          <a href="{% url 'self_service' %}">リンク状況確認</a>
+          {% if user.is_staff %}
+          <a href="{% url 'broadcast' %}">ロールDM送信</a>
+          {% endif %}
           <a href="/accounts/logout/">ログアウト</a>
           {% else %}
           <a href="/accounts/twitch/login/">Twitchでログイン</a>

--- a/webadmin/panel/templates/panel/index.html
+++ b/webadmin/panel/templates/panel/index.html
@@ -1,21 +1,235 @@
-
 {% extends "panel/base.html" %}
-{% block title %}ダッシュボード | NeiBot 管理パネル{% endblock %}
+{% block title %}運用ダッシュボード | NeiBot 管理パネル{% endblock %}
 
 {% block content %}
-<div class="card">
-  <h1>ダッシュボード</h1>
-  {% if user.is_authenticated %}
-  <p class="text-muted">{{ user.username }} でログイン中です。</p>
-  <div class="actions">
-    <a class="button-link" href="{% url 'broadcast' %}">ロールDM送信へ移動</a>
-    <a class="button-link" href="/accounts/logout/">ログアウト</a>
+{% if user.is_authenticated %}
+  {% if dashboard %}
+  <div class="card">
+    <h1>運用ダッシュボード</h1>
+    <p class="text-muted">Twitch 連携とリマインド運用の最新状況を確認できます。</p>
+
+    <div class="stat-grid">
+      <div class="stat-card">
+        <div class="stat-label">連携済みユーザー</div>
+        <div class="stat-value">{{ dashboard.user_stats.total }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">アクティブ（サブスク）</div>
+        <div class="stat-value">{{ dashboard.user_stats.active }}</div>
+        <div class="stat-subtext">{{ dashboard.user_stats.active_ratio }}%</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">今月確認済み</div>
+        <div class="stat-value">{{ dashboard.user_stats.verified_this_month }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">要再リンク</div>
+        <div class="stat-value">{{ dashboard.user_stats.pending_relink }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">DM エラー</div>
+        <div class="stat-value">{{ dashboard.user_stats.dm_failures }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">最終更新</div>
+        <div class="stat-value">
+          {% if dashboard.user_stats.last_updated %}
+            {{ dashboard.user_stats.last_updated|date:"n月j日 H:i" }}
+          {% else %}
+            –
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    <div class="tier-breakdown">
+      <h2 class="section-title">Tier 内訳</h2>
+      <ul class="tier-list">
+        {% for tier in dashboard.tier_breakdown %}
+        <li>
+          <span class="tier-label">{{ tier.label }}</span>
+          <span class="tier-count">{{ tier.count }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>リマインド状況</h2>
+    <div class="stat-grid">
+      <div class="stat-card">
+        <div class="stat-label">今月送信済み</div>
+        <div class="stat-value">{{ dashboard.reminder_stats.reminders_sent_this_month }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">7日以上未解決</div>
+        <div class="stat-value">{{ dashboard.reminder_stats.pending_over_7_days }}</div>
+      </div>
+    </div>
+
+    {% if dashboard.unresolved_samples %}
+    <div class="status-section">
+      <h3>未解決ユーザー（抜粋）</h3>
+      <ul class="status-list">
+        {% for sample in dashboard.unresolved_samples %}
+        <li>
+          <div class="status-header">
+            <span class="status-title">Discord ID: <code>{{ sample.discord_id }}</code></span>
+            {% if sample.twitch_username %}
+            <span class="status-meta">Twitch: {{ sample.twitch_username }}</span>
+            {% endif %}
+          </div>
+          <div class="status-body">
+            {% if sample.last_notice_at %}
+            <span>最終通知: {{ sample.last_notice_at|date:"n月j日 H:i" }}</span>
+            {% else %}
+            <span>最終通知: –</span>
+            {% endif %}
+            {% if sample.days_since_notice is not None %}
+            <span>（{{ sample.days_since_notice }} 日前）</span>
+            {% endif %}
+            {% if sample.last_verified_at %}
+            <span> / 最終確認: {{ sample.last_verified_at|date:"n月j日" }}</span>
+            {% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    {% if dashboard.dm_failure_samples %}
+    <div class="status-section">
+      <h3>DM エラー（最近5件）</h3>
+      <ul class="status-list">
+        {% for sample in dashboard.dm_failure_samples %}
+        <li>
+          <div class="status-header">
+            <span class="status-title">Discord ID: <code>{{ sample.discord_id }}</code></span>
+            {% if sample.twitch_username %}
+            <span class="status-meta">Twitch: {{ sample.twitch_username }}</span>
+            {% endif %}
+          </div>
+          <div class="status-body">
+            {% if sample.updated_at %}
+            <span>最終更新: {{ sample.updated_at|date:"n月j日 H:i" }}</span>
+            {% else %}
+            <span>最終更新: –</span>
+            {% endif %}
+            {% if sample.reason %}
+            <span class="status-note">理由: {{ sample.reason }}</span>
+            {% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+  </div>
+
+  <div class="card">
+    <h2>EventSub 受信ログ</h2>
+    <div class="stat-grid">
+      <div class="stat-card">
+        <div class="stat-label">保留中</div>
+        <div class="stat-value">{{ dashboard.event_stats.pending }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">エラー</div>
+        <div class="stat-value">{{ dashboard.event_stats.failed }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">直近24時間</div>
+        <div class="stat-value">{{ dashboard.event_stats.events_last_24h }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">直近7日間</div>
+        <div class="stat-value">{{ dashboard.event_stats.events_last_7d }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">最終受信</div>
+        <div class="stat-value">
+          {% if dashboard.event_stats.last_event_at %}
+            {{ dashboard.event_stats.last_event_at|date:"n月j日 H:i" }}
+          {% else %}
+            –
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    {% if dashboard.recent_events %}
+    <div class="table-wrapper">
+      <table class="event-table">
+        <thead>
+          <tr>
+            <th>受信日時</th>
+            <th>イベント</th>
+            <th>Twitch ID</th>
+            <th>ステータス</th>
+            <th>リトライ</th>
+            <th>エラー</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for event in dashboard.recent_events %}
+          <tr>
+            <td>{% if event.received_at %}{{ event.received_at|date:"n月j日 H:i" }}{% else %}–{% endif %}</td>
+            <td>{{ event.event_type }}</td>
+            <td>{% if event.twitch_user_id %}{{ event.twitch_user_id }}{% else %}–{% endif %}</td>
+            <td><span class="status-badge is-{{ event.status_level }}">{{ event.status }}</span></td>
+            <td>{{ event.retries }}</td>
+            <td>{% if event.error %}<span class="text-muted">{{ event.error|truncatechars:40 }}</span>{% else %}–{% endif %}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <p class="text-muted">受信ログはまだありません。</p>
+    {% endif %}
+
+    {% if dashboard.recent_failures %}
+    <div class="status-section">
+      <h3>直近のエラー</h3>
+      <ul class="status-list">
+        {% for failure in dashboard.recent_failures %}
+        <li>
+          <div class="status-header">
+            <span class="status-title">Delivery ID: <code>{{ failure.delivery_id }}</code></span>
+            <span class="status-meta">{{ failure.event_type }}</span>
+          </div>
+          <div class="status-body">
+            {% if failure.received_at %}
+            <span>受信: {{ failure.received_at|date:"n月j日 H:i" }}</span>
+            {% endif %}
+            {% if failure.retries %}
+            <span> / リトライ: {{ failure.retries }}</span>
+            {% endif %}
+            {% if failure.error %}
+            <span class="status-note">{{ failure.error }}</span>
+            {% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
   </div>
   {% else %}
-  <p class="text-muted">管理機能へアクセスするにはログインしてください。</p>
-  <div class="actions">
-    <a class="button-primary" href="/accounts/twitch/login/">Twitchでログイン</a>
+  <div class="card">
+    <h1>ダッシュボード</h1>
+    <p class="text-muted">このアカウントにはダッシュボードへのアクセス権がありません。</p>
   </div>
   {% endif %}
-</div>
+{% else %}
+  <div class="card">
+    <h1>NeiBot 管理パネルへようこそ</h1>
+    <p class="text-muted">運用状況を確認したり、ロール DM を送信するには Twitch でログインしてください。</p>
+    <div class="actions">
+      <a class="button-primary" href="/accounts/twitch/login/">Twitchでログイン</a>
+    </div>
+  </div>
+{% endif %}
 {% endblock %}

--- a/webadmin/panel/templates/panel/status.html
+++ b/webadmin/panel/templates/panel/status.html
@@ -1,0 +1,180 @@
+{% extends "panel/base.html" %}
+{% block title %}リンク状況の確認 | NeiBot 管理パネル{% endblock %}
+
+{% block content %}
+<div class="card">
+  <h1>リンク状況の確認</h1>
+  {% if twitch_profile.display_name or twitch_profile.login %}
+  <div class="profile-summary">
+    {% if twitch_profile.profile_image_url %}
+    <img class="profile-avatar" src="{{ twitch_profile.profile_image_url }}" alt="Twitch アイコン" loading="lazy" />
+    {% endif %}
+    <div>
+      <div class="profile-name">{{ twitch_profile.display_name|default:twitch_profile.login }}</div>
+      {% if twitch_profile.login %}
+      <div class="text-muted">ログイン名: {{ twitch_profile.login }}</div>
+      {% endif %}
+      {% if twitch_profile.id %}
+      <div class="text-muted">Twitch ID: {{ twitch_profile.id }}</div>
+      {% endif %}
+    </div>
+  </div>
+  {% else %}
+  <p class="text-muted">Twitch アカウント情報を取得できませんでした。</p>
+  {% endif %}
+  <p class="text-muted">
+    Discord サーバーで <code>/link</code> を実行すると、最新のサブスク状態がこのページに反映されます。
+  </p>
+</div>
+
+{% if linked_entries %}
+<div class="status-grid">
+  {% for entry in linked_entries %}
+  <article class="status-card">
+    <header class="status-card-header">
+      <div>
+        <h2>Discord ID: <a href="{{ entry.discord_profile_url }}" target="_blank" rel="noopener">{{ entry.discord_id }}</a></h2>
+        {% if entry.twitch_username %}
+        <p class="text-muted">Twitch: {{ entry.twitch_username }}</p>
+        {% endif %}
+      </div>
+      <div class="status-badges">
+        {% for badge in entry.status_badges %}
+        <span class="status-badge is-{{ badge.level }}">{{ badge.label }}</span>
+        {% endfor %}
+      </div>
+    </header>
+    <div class="status-card-body">
+      <dl class="data-list">
+        <div>
+          <dt>Tier</dt>
+          <dd>{{ entry.tier_label }}</dd>
+        </div>
+        <div>
+          <dt>連続月数</dt>
+          <dd>{{ entry.streak_months }} ヶ月</dd>
+        </div>
+        <div>
+          <dt>累計月数</dt>
+          <dd>{{ entry.cumulative_months }} ヶ月</dd>
+        </div>
+        {% if entry.bits_score or entry.bits_rank %}
+        <div>
+          <dt>Bits</dt>
+          <dd>
+            {% if entry.bits_score %}{{ entry.bits_score }} pt{% endif %}
+            {% if entry.bits_rank %}（順位: {{ entry.bits_rank }}）{% endif %}
+          </dd>
+        </div>
+        {% endif %}
+        <div>
+          <dt>サブスク開始</dt>
+          <dd>
+            {% if entry.subscribed_since %}
+              {{ entry.subscribed_since|date:"Y年n月j日" }}
+            {% else %}
+              –
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>最終確認</dt>
+          <dd>
+            {% if entry.last_verified_at %}
+              {{ entry.last_verified_at|date:"Y年n月j日" }}
+            {% else %}
+              未確認
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>次回目安</dt>
+          <dd>
+            {% if entry.next_due_date %}
+              {{ entry.next_due_date|date:"Y年n月j日" }}
+              {% if entry.days_until_due is not None %}
+                （
+                {% if entry.days_until_due > 0 %}
+                  あと {{ entry.days_until_due }} 日
+                {% elif entry.days_until_due == 0 %}
+                  本日
+                {% else %}
+                  {{ entry.days_until_due_abs }} 日前
+                {% endif %}
+                ）
+              {% endif %}
+            {% else %}
+              –
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>最終通知</dt>
+          <dd>
+            {% if entry.last_notice_at %}
+              {{ entry.last_notice_at|date:"Y年n月j日 H:i" }}
+              {% if entry.days_since_notice is not None %}
+                （{{ entry.days_since_notice }} 日前）
+              {% endif %}
+            {% else %}
+              –
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>初回通知</dt>
+          <dd>
+            {% if entry.first_notice_at %}
+              {{ entry.first_notice_at|date:"Y年n月j日 H:i" }}
+            {% else %}
+              –
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>最終更新</dt>
+          <dd>
+            {% if entry.updated_at %}
+              {{ entry.updated_at|date:"Y年n月j日 H:i" }}
+            {% else %}
+              –
+            {% endif %}
+          </dd>
+        </div>
+      </dl>
+
+      {% if entry.status_notes %}
+      <div class="note-section">
+        <h3>アクションのヒント</h3>
+        <ul class="note-list">
+          {% for note in entry.status_notes %}
+          <li>{{ note }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+    </div>
+  </article>
+  {% endfor %}
+</div>
+{% else %}
+<div class="card">
+  <h2>リンク情報が見つかりませんでした</h2>
+  <p class="text-muted">まだ Discord との連携が完了していないか、別の Twitch アカウントでログインしている可能性があります。</p>
+  <ol class="guide-list">
+    <li>Discord サーバーに参加し、サーバー内で <code>/link</code> コマンドを実行してください。</li>
+    <li>Bot からの DM が届かない場合は、Discord のプライバシー設定で「サーバーのメンバーからのダイレクトメッセージを許可する」をオンにしてください。</li>
+    <li>リンク後も反映されない場合は、数分待ってからこのページを再読み込みしてください。</li>
+  </ol>
+</div>
+{% endif %}
+
+<div class="card">
+  <h2>セルフヘルプ</h2>
+  <ol class="guide-list">
+    <li>月初に <code>/link</code> を再実行すると、サブスク特典を継続できます。</li>
+    <li>再リンク DM が届かないときは、DM 設定やサーバーのミュート設定をご確認ください。</li>
+    <li>状況が改善しない場合は、運営チームまで Discord でご連絡ください。</li>
+  </ol>
+</div>
+{% endblock %}

--- a/webadmin/panel/urls.py
+++ b/webadmin/panel/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("status/", views.self_service, name="self_service"),
     path("broadcast/", views.broadcast, name="broadcast"),
 ]
 

--- a/webadmin/panel/views.py
+++ b/webadmin/panel/views.py
@@ -1,22 +1,500 @@
+from __future__ import annotations
 
+import datetime as dt
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import redirect, render
-from allauth.socialaccount.models import SocialAccount
+from django.utils import timezone
+from django.utils.dateparse import parse_date, parse_datetime
+
 from .forms import RoleBroadcastForm
-import requests
-from pathlib import Path
+from .models import LinkedUser, WebhookEvent
+
+TIER_LABELS: List[Tuple[str, str]] = [
+    ("1000", "Tier 1"),
+    ("2000", "Tier 2"),
+    ("3000", "Tier 3"),
+]
+
+STATUS_LABELS: Dict[str, Tuple[str, str]] = {
+    "done": ("処理済み", "success"),
+    "pending": ("処理待ち", "warning"),
+    "failed": ("エラー", "danger"),
+}
+
+
+def _parse_iso_datetime(value: Any) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    if isinstance(value, dt.datetime):
+        dt_value = value
+    elif isinstance(value, dt.date):
+        dt_value = dt.datetime.combine(value, dt.time.min)
+    else:
+        value_str = str(value).strip()
+        if not value_str:
+            return None
+        if value_str.endswith("Z"):
+            value_str = value_str[:-1] + "+00:00"
+        dt_value = parse_datetime(value_str)
+        if dt_value is None:
+            try:
+                dt_value = dt.datetime.fromisoformat(value_str)
+            except ValueError:
+                return None
+    if timezone.is_naive(dt_value):
+        dt_value = timezone.make_aware(dt_value, timezone.get_default_timezone())
+    return dt_value
+
+
+def _parse_iso_date(value: Any) -> Optional[dt.date]:
+    if not value:
+        return None
+    if isinstance(value, dt.date) and not isinstance(value, dt.datetime):
+        return value
+    if isinstance(value, dt.datetime):
+        return value.date()
+    value_str = str(value).strip()
+    if not value_str:
+        return None
+    parsed = parse_date(value_str)
+    if parsed:
+        return parsed
+    dt_value = parse_datetime(value_str)
+    if dt_value:
+        return dt_value.date()
+    try:
+        return dt.date.fromisoformat(value_str[:10])
+    except ValueError:
+        return None
+
+
+def _first_day_next_month(d: dt.date) -> dt.date:
+    if d.month == 12:
+        return dt.date(d.year + 1, 1, 1)
+    return dt.date(d.year, d.month + 1, 1)
+
+
+def _to_local(dt_value: Optional[dt.datetime]) -> Optional[dt.datetime]:
+    if dt_value is None:
+        return None
+    if timezone.is_naive(dt_value):
+        dt_value = timezone.make_aware(dt_value, timezone.get_default_timezone())
+    return timezone.localtime(dt_value)
+
+
+def _build_dashboard_context() -> Dict[str, Any]:
+    now = timezone.now()
+    today = timezone.localdate()
+    first_of_month = today.replace(day=1)
+
+    try:
+        linked_users = list(LinkedUser.objects.all())
+    except Exception:
+        linked_users = []
+
+    user_stats: Dict[str, Any] = {
+        "total": 0,
+        "active": 0,
+        "verified_this_month": 0,
+        "stale_records": 0,
+        "pending_relink": 0,
+        "dm_failures": 0,
+        "last_updated": None,
+    }
+    reminder_stats: Dict[str, Any] = {
+        "reminders_sent_this_month": 0,
+        "pending_over_7_days": 0,
+    }
+    tier_counter: Counter[str] = Counter()
+    unresolved_samples: List[Dict[str, Any]] = []
+    dm_failure_samples: List[Dict[str, Any]] = []
+    latest_update: Optional[dt.datetime] = None
+
+    for linked in linked_users:
+        data = linked.data if isinstance(linked.data, dict) else {}
+        if not isinstance(data, dict):
+            data = {}
+
+        user_stats["total"] += 1
+
+        tier = str(data.get("tier") or "")
+        if tier:
+            tier_counter[tier] += 1
+        if data.get("is_subscriber") or tier:
+            user_stats["active"] += 1
+
+        resolved = bool(data.get("resolved", True))
+        if not resolved:
+            user_stats["pending_relink"] += 1
+
+        if data.get("dm_failed"):
+            user_stats["dm_failures"] += 1
+
+        last_verified_at = _parse_iso_date(data.get("last_verified_at"))
+        if last_verified_at and last_verified_at >= first_of_month:
+            user_stats["verified_this_month"] += 1
+        else:
+            user_stats["stale_records"] += 1
+
+        last_notice_dt = _to_local(_parse_iso_datetime(data.get("last_notice_at")))
+        if last_notice_dt and last_notice_dt.date() >= first_of_month:
+            reminder_stats["reminders_sent_this_month"] += 1
+
+        days_since_notice = None
+        if last_notice_dt:
+            days_since_notice = (today - last_notice_dt.date()).days
+        if not resolved and days_since_notice is not None and days_since_notice >= 7:
+            reminder_stats["pending_over_7_days"] += 1
+
+        if not resolved:
+            unresolved_samples.append(
+                {
+                    "discord_id": linked.discord_id,
+                    "twitch_username": data.get("twitch_username") or "",
+                    "last_notice_at": last_notice_dt,
+                    "days_since_notice": days_since_notice,
+                    "last_verified_at": last_verified_at,
+                }
+            )
+
+        if data.get("dm_failed"):
+            dm_failure_samples.append(
+                {
+                    "discord_id": linked.discord_id,
+                    "twitch_username": data.get("twitch_username") or "",
+                    "reason": data.get("dm_failed_reason") or "",
+                    "last_notice_at": last_notice_dt,
+                    "updated_at": _to_local(_parse_iso_datetime(linked.updated_at)),
+                }
+            )
+
+        updated_at = _parse_iso_datetime(linked.updated_at)
+        if updated_at and (latest_update is None or updated_at > latest_update):
+            latest_update = updated_at
+
+    user_stats["last_updated"] = _to_local(latest_update)
+    if user_stats["total"]:
+        user_stats["active_ratio"] = round(
+            (user_stats["active"] / user_stats["total"]) * 100, 1
+        )
+    else:
+        user_stats["active_ratio"] = 0
+
+    tier_breakdown: List[Dict[str, Any]] = []
+    counted = 0
+    for code, label in TIER_LABELS:
+        count = tier_counter.get(code, 0)
+        counted += count
+        tier_breakdown.append({"code": code, "label": label, "count": count})
+    tier_breakdown.append(
+        {
+            "code": "none",
+            "label": "未サブスク",
+            "count": max(user_stats["total"] - counted, 0),
+        }
+    )
+
+    try:
+        events_queryset = list(WebhookEvent.objects.order_by("-received_at")[:200])
+    except Exception:
+        events_queryset = []
+
+    event_stats: Dict[str, Any] = {
+        "pending": 0,
+        "failed": 0,
+        "events_last_24h": 0,
+        "events_last_7d": 0,
+        "last_event_at": None,
+    }
+    try:
+        event_stats["pending"] = WebhookEvent.objects.filter(status="pending").count()
+    except Exception:
+        event_stats["pending"] = 0
+    try:
+        event_stats["failed"] = WebhookEvent.objects.filter(status="failed").count()
+    except Exception:
+        event_stats["failed"] = 0
+
+    day_cutoff = now - dt.timedelta(days=1)
+    week_cutoff = now - dt.timedelta(days=7)
+
+    recent_events: List[Dict[str, Any]] = []
+    recent_failures: List[Dict[str, Any]] = []
+
+    for event in events_queryset:
+        received_dt = _parse_iso_datetime(event.received_at)
+        local_received = _to_local(received_dt)
+        if event_stats["last_event_at"] is None and local_received:
+            event_stats["last_event_at"] = local_received
+
+        if received_dt:
+            if received_dt >= day_cutoff:
+                event_stats["events_last_24h"] += 1
+            if received_dt >= week_cutoff:
+                event_stats["events_last_7d"] += 1
+
+        status_key = str(event.status or "").lower()
+        status_label: str
+        status_level: str
+        status_pair = STATUS_LABELS.get(status_key)
+        if status_pair:
+            status_label, status_level = status_pair
+        else:
+            status_label = str(event.status or "不明")
+            status_level = "muted"
+
+        if len(recent_events) < 12:
+            recent_events.append(
+                {
+                    "delivery_id": event.delivery_id,
+                    "event_type": event.event_type,
+                    "source": event.source,
+                    "status": status_label,
+                    "status_level": status_level,
+                    "twitch_user_id": event.twitch_user_id,
+                    "received_at": local_received,
+                    "retries": event.retries,
+                    "error": event.error,
+                }
+            )
+
+        if status_level == "danger" and len(recent_failures) < 3:
+            recent_failures.append(
+                {
+                    "delivery_id": event.delivery_id,
+                    "event_type": event.event_type,
+                    "received_at": local_received,
+                    "error": event.error,
+                    "retries": event.retries,
+                }
+            )
+
+    fallback_dt = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+    unresolved_samples_sorted = sorted(
+        unresolved_samples,
+        key=lambda item: (
+            item.get("last_notice_at") or fallback_dt,
+            item.get("discord_id"),
+        ),
+    )[:5]
+
+    dm_failure_samples_sorted = sorted(
+        dm_failure_samples,
+        key=lambda item: (
+            item.get("updated_at") or fallback_dt,
+            item.get("discord_id"),
+        ),
+        reverse=True,
+    )[:5]
+
+    return {
+        "user_stats": user_stats,
+        "tier_breakdown": tier_breakdown,
+        "reminder_stats": reminder_stats,
+        "unresolved_samples": unresolved_samples_sorted,
+        "dm_failure_samples": dm_failure_samples_sorted,
+        "event_stats": event_stats,
+        "recent_events": recent_events,
+        "recent_failures": recent_failures,
+    }
+
+
+def _build_self_service_entry(
+    linked: LinkedUser, data: Dict[str, Any], *, today: dt.date
+) -> Dict[str, Any]:
+    tier = str(data.get("tier") or "")
+    tier_label = dict(TIER_LABELS).get(tier, "未登録") if tier else "未登録"
+    is_subscriber = bool(data.get("is_subscriber")) or bool(tier)
+
+    last_verified_at = _parse_iso_date(data.get("last_verified_at"))
+    linked_date = _parse_iso_date(data.get("linked_date"))
+    subscribed_since = _parse_iso_date(data.get("subscribed_since"))
+    basis = last_verified_at or linked_date
+    next_due = _first_day_next_month(basis.replace(day=1)) if basis else None
+    days_until_due = (next_due - today).days if next_due else None
+    days_until_due_abs = abs(days_until_due) if days_until_due is not None else None
+
+    last_notice_dt = _to_local(_parse_iso_datetime(data.get("last_notice_at")))
+    first_notice_dt = _to_local(_parse_iso_datetime(data.get("first_notice_at")))
+    days_since_notice = (
+        (today - last_notice_dt.date()).days if last_notice_dt else None
+    )
+
+    dm_failed = bool(data.get("dm_failed"))
+    resolved = bool(data.get("resolved", True))
+
+    status_badges: List[Dict[str, str]] = []
+    if not resolved:
+        status_badges.append({"label": "要対応", "level": "warning"})
+    if dm_failed:
+        status_badges.append({"label": "DM未達", "level": "danger"})
+    if not is_subscriber:
+        status_badges.append({"label": "未サブスク", "level": "muted"})
+    if next_due is not None and days_until_due is not None:
+        if days_until_due < 0:
+            status_badges.append({"label": "期限超過", "level": "danger"})
+        elif days_until_due <= 5:
+            status_badges.append({"label": "まもなく更新", "level": "warning"})
+    if not status_badges:
+        status_badges.append({"label": "良好", "level": "success"})
+
+    status_notes: List[str] = []
+    if not resolved:
+        status_notes.append("サーバーで /link を実行すると解消されます。")
+        if days_since_notice is not None and days_since_notice >= 7:
+            status_notes.append("自動リマインドの再送が間もなく実行されます。")
+    if dm_failed:
+        reason = data.get("dm_failed_reason")
+        if reason:
+            status_notes.append(f"直近のDM送信が失敗しました: {reason}")
+        else:
+            status_notes.append("Discordのプライバシー設定でサーバーからのDMを許可してください。")
+    if next_due is not None and days_until_due is not None:
+        if days_until_due < 0:
+            status_notes.append("今月分の再リンクが未確認です。/link を実行して更新してください。")
+        elif days_until_due <= 5:
+            status_notes.append("まもなく翌月の確認タイミングです。月初に /link を実行するとスムーズです。")
+    if not is_subscriber:
+        status_notes.append("現在Twitchサブスク登録が確認できません。登録状況をご確認ください。")
+
+    deduped_notes = list(dict.fromkeys(status_notes))
+
+    bits_score = data.get("bits_score")
+    if isinstance(bits_score, int) and bits_score <= 0:
+        bits_score = None
+
+    return {
+        "discord_id": linked.discord_id,
+        "discord_profile_url": f"https://discord.com/users/{linked.discord_id}",
+        "twitch_username": data.get("twitch_username") or "",
+        "twitch_user_id": data.get("twitch_user_id") or "",
+        "tier": tier,
+        "tier_label": tier_label,
+        "is_subscriber": is_subscriber,
+        "streak_months": int(data.get("streak_months") or 0),
+        "cumulative_months": int(data.get("cumulative_months") or 0),
+        "bits_score": bits_score,
+        "bits_rank": data.get("bits_rank"),
+        "linked_date": linked_date,
+        "subscribed_since": subscribed_since,
+        "last_verified_at": last_verified_at,
+        "first_notice_at": first_notice_dt,
+        "last_notice_at": last_notice_dt,
+        "days_since_notice": days_since_notice,
+        "resolved": resolved,
+        "dm_failed": dm_failed,
+        "dm_failed_reason": data.get("dm_failed_reason"),
+        "next_due_date": next_due,
+        "days_until_due": days_until_due,
+        "days_until_due_abs": days_until_due_abs,
+        "status_badges": status_badges,
+        "status_notes": deduped_notes,
+        "updated_at": _to_local(_parse_iso_datetime(linked.updated_at)),
+    }
+
+
+def _collect_self_service_entries(
+    twitch_profile: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    today = timezone.localdate()
+    twitch_id = str(twitch_profile.get("id") or "").strip()
+    twitch_login = str(twitch_profile.get("login") or "").lower().strip()
+
+    try:
+        linked_users = list(LinkedUser.objects.all())
+    except Exception:
+        linked_users = []
+
+    entries: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for linked in linked_users:
+        data = linked.data if isinstance(linked.data, dict) else {}
+        if not isinstance(data, dict):
+            data = {}
+        user_id = str(data.get("twitch_user_id") or "").strip()
+        login = str(data.get("twitch_username") or "").lower().strip()
+
+        matched = False
+        if twitch_id and user_id and twitch_id == user_id:
+            matched = True
+        elif twitch_login and login and twitch_login == login:
+            matched = True
+        if not matched:
+            continue
+
+        entry = _build_self_service_entry(linked, data, today=today)
+        if entry["discord_id"] in seen:
+            continue
+        seen.add(entry["discord_id"])
+        entries.append(entry)
+
+    entries.sort(key=lambda item: item["discord_id"])
+    return entries
 
 
 def index(request: HttpRequest) -> HttpResponse:
-    return render(request, "panel/index.html")
+    if request.user.is_authenticated and not request.user.is_staff:
+        return redirect("self_service")
+
+    dashboard = None
+    if request.user.is_authenticated and request.user.is_staff:
+        dashboard = _build_dashboard_context()
+
+    return render(request, "panel/index.html", {"dashboard": dashboard})
+
+
+@login_required
+def self_service(request: HttpRequest) -> HttpResponse:
+    twitch_account = None
+    try:
+        twitch_account = SocialAccount.objects.filter(
+            user=request.user, provider="twitch"
+        ).first()
+    except Exception:
+        twitch_account = None
+
+    profile: Dict[str, Any] = {
+        "display_name": "",
+        "login": "",
+        "id": "",
+        "profile_image_url": "",
+    }
+    if twitch_account:
+        extra = twitch_account.extra_data or {}
+        profile = {
+            "display_name": extra.get("display_name")
+            or extra.get("preferred_username")
+            or request.user.username,
+            "login": extra.get("login") or extra.get("preferred_username") or "",
+            "id": str(extra.get("id") or extra.get("sub") or ""),
+            "profile_image_url": extra.get("profile_image_url") or "",
+        }
+
+    entries = _collect_self_service_entries(profile)
+
+    return render(
+        request,
+        "panel/status.html",
+        {
+            "twitch_profile": profile,
+            "linked_entries": entries,
+        },
+    )
 
 
 @login_required
 def broadcast(request: HttpRequest) -> HttpResponse:
-    # Staff only
     if not request.user.is_staff:
         return HttpResponseForbidden("このページへアクセスする権限がありません。")
 
@@ -31,27 +509,31 @@ def broadcast(request: HttpRequest) -> HttpResponse:
             file_url = None
             file_path = None
 
-            # Save attachment (if any) and build absolute URL
             f = form.cleaned_data.get("attachment")
             if f:
-                from django.core.files.storage import default_storage
                 from django.core.files.base import ContentFile
+                from django.core.files.storage import default_storage
 
-                # Save into MEDIA_ROOT/uploads and build both absolute URL and local path
-                rel_path = default_storage.save(f"uploads/{f.name}", ContentFile(f.read()))
-                # Normalize URL path
+                rel_path = default_storage.save(
+                    f"uploads/{f.name}", ContentFile(f.read())
+                )
                 url_path = str(rel_path).replace("\\", "/").lstrip("/")
                 file_url = request.build_absolute_uri(settings.MEDIA_URL + url_path)
-                # Absolute filesystem path for the bot (runs on same host)
                 file_path = str((Path(settings.MEDIA_ROOT) / rel_path).resolve())
 
-            headers = {"Authorization": f"Bearer {settings.ADMIN_API_TOKEN}"} if settings.ADMIN_API_TOKEN else {}
-            role_labels = {str(value): label for value, label in form.fields["role_ids"].choices}
-            success_roles: list[str] = []
-            failed_roles: list[tuple[str, str]] = []
+            headers = (
+                {"Authorization": f"Bearer {settings.ADMIN_API_TOKEN}"}
+                if settings.ADMIN_API_TOKEN
+                else {}
+            )
+            role_labels = {
+                str(value): label for value, label in form.fields["role_ids"].choices
+            }
+            success_roles: List[str] = []
+            failed_roles: List[Tuple[str, str]] = []
 
             for rid in role_ids:
-                payload = {"role_id": rid, "message": message}
+                payload: Dict[str, Any] = {"role_id": rid, "message": message}
                 if guild_id:
                     payload["guild_id"] = guild_id
                 if file_url:
@@ -59,25 +541,29 @@ def broadcast(request: HttpRequest) -> HttpResponse:
                 if file_path:
                     payload["file_path"] = file_path
                 try:
-                    r = requests.post(
+                    resp = requests.post(
                         f"{settings.BOT_ADMIN_API_BASE}/send_role_dm",
                         json=payload,
                         headers=headers,
                         timeout=10,
                     )
-                except Exception as e:
-                    failed_roles.append((role_labels.get(str(rid), str(rid)), str(e)))
+                except Exception as exc:
+                    failed_roles.append(
+                        (role_labels.get(str(rid), str(rid)), str(exc))
+                    )
                     continue
 
-                if r.status_code == 200:
+                if resp.status_code == 200:
                     success_roles.append(role_labels.get(str(rid), str(rid)))
                 else:
-                    reason = f"{r.status_code} {r.text}".strip()
+                    reason = f"{resp.status_code} {resp.text}".strip()
                     failed_roles.append((role_labels.get(str(rid), str(rid)), reason))
 
             if success_roles:
                 if len(success_roles) == 1:
-                    messages.success(request, f"「{success_roles[0]}」への送信をキューに投入しました。")
+                    messages.success(
+                        request, f"「{success_roles[0]}」への送信をキューに投入しました。"
+                    )
                 else:
                     joined = "、".join(success_roles)
                     messages.success(
@@ -85,17 +571,20 @@ def broadcast(request: HttpRequest) -> HttpResponse:
                         f"{len(success_roles)}件のロール（{joined}）への送信をキューに投入しました。",
                     )
             for label, reason in failed_roles:
-                messages.error(request, f"ロール「{label}」への送信に失敗しました: {reason}")
+                messages.error(
+                    request, f"ロール「{label}」への送信に失敗しました: {reason}"
+                )
 
             if not failed_roles:
                 return redirect("broadcast")
     else:
         form = RoleBroadcastForm()
 
-    # Show current Twitch login (if any)
     twitch_account = None
     try:
-        twitch_account = SocialAccount.objects.filter(user=request.user, provider="twitch").first()
+        twitch_account = SocialAccount.objects.filter(
+            user=request.user, provider="twitch"
+        ).first()
     except Exception:
         twitch_account = None
 

--- a/webadmin/webadmin/settings.py
+++ b/webadmin/webadmin/settings.py
@@ -113,10 +113,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # allauth
 SITE_ID = 1
 LOGIN_URL = "/accounts/login/"
-LOGIN_REDIRECT_URL = "/broadcast/"
+LOGIN_REDIRECT_URL = "/"
 # Ensure allauth also uses the same redirect
 ACCOUNT_LOGIN_REDIRECT_URL = LOGIN_REDIRECT_URL
-LOGOUT_REDIRECT_URL = "/broadcast/"
+LOGOUT_REDIRECT_URL = "/"
 ACCOUNT_LOGOUT_REDIRECT_URL = LOGOUT_REDIRECT_URL
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
## Summary
- introduce an authenticated self-service page at `/status/` where viewers can review their latest Twitch/Discord link status, streaks and next re-link guidance
- expand the home dashboard for staff with live linked-user metrics, reminder health, and recent EventSub delivery status
- refresh shared styling/navigation to support the new dashboard cards, status badges, and tables

## Testing
- python webadmin/manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68c9b6134ec8832fb022871282e47aa3